### PR TITLE
#159893981 Fix router links not matching pathname in GH pages

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -734,17 +734,18 @@ if (reminderSetter) reminderSetter.addEventListener('change', updateProfile);
 
 const resolveRoute = () => {
   // get url
-  const path = window.location.pathname;
+  const pathArray = window.location.pathname.split('/');
+  const pagePath = pathArray[pathArray.length - 1];
   const queries = queryToJSON(window.location.search);
   // match path -- switch(n)
-  switch (path) {
-    case '/stories.html':
+  switch (pagePath) {
+    case 'stories.html':
       loadStories(queries);
       break;
-    case '/story.html':
+    case 'story.html':
       loadStory(queries);
       break;
-    case '/profile.html':
+    case 'profile.html':
       loadProfile();
       break;
     default:


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug in `js/main.js` where expected route arguments don't exactly match pathname when deployed to Github Pages
#### Description of Task to be completed

- Extract route to be independent of hostname and prefix path

#### How should this be manually tested?

- Pull branch into local machine
- `cd my-diary-client`
- Start a live server
- Point a browser to navigate the changes

#### What are the relevant pivotal tracker stories?

[#159893981](https://www.pivotaltracker.com/story/show/159893981)
