### PR TITLE
Fix service worker relative path

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -857,7 +857,7 @@ window.addEventListener('DOMContentLoaded', resolveRoute);
 const registerServiceWorker = async () => {
   if ('serviceWorker' in navigator && 'PushManager' in window) {
     try {
-      swRegistration = await navigator.serviceWorker.register('/sw.js');
+      swRegistration = await navigator.serviceWorker.register('../sw.js');
       subscription = await swRegistration.pushManager.getSubscription();
     } catch (e) {
       // push notifications not available on device or browser


### PR DESCRIPTION
#### What does this PR do?

Makes service worker registration to use a relative path to `main.js`
#### Description of Task to be completed

- Change `sw.js` load path to current folder relative in service worker registration

#### How should this be manually tested?

- Pull branch into local machine
- `cd my-diary-client`
- Start a live server
- Service worker should be registered normally with new path
